### PR TITLE
Remove sonar cloud from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,14 @@ addons:
   firefox: latest
   apt:
     packages:
-      - chromium-chromedriver
-  sonarcloud:
-    organization: retest
-    token:
-      secure: "${SONAR_CLOUD_TOKEN}"
+    - chromium-chromedriver
 
 notifications:
   email: false
 
 cache:
   directories:
-    - "${HOME}/.sonar/cache/"
-    - "${HOME}/.m2/"
+  - "${HOME}/.m2/"
 
 install: true
 
@@ -34,12 +29,12 @@ script: ci/script.sh
 before_deploy: ci/before_deploy.sh
 
 deploy:
-  - provider: script
-    script: ci/deploy.sh
-    on:
-      tags: true
-  - provider: releases
-    api_key: "${GH_TOKEN}"
-    draft: true
-    on:
-      tags: true
+- provider: script
+  script: ci/deploy.sh
+  on:
+    tags: true
+- provider: releases
+  api_key: "${GH_TOKEN}"
+  draft: true
+  on:
+    tags: true

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,8 +11,4 @@ mvn ${MVN_ARGS} clean package -DskipTests
 # Test with JDK 13
 wget --quiet https://github.com/sormuras/bach/raw/master/install-jdk.sh && . ./install-jdk.sh -F 13
 
-if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
-    mvn ${MVN_ARGS} org.jacoco:jacoco-maven-plugin:prepare-agent test verify sonar:sonar
-else
-    mvn ${MVN_ARGS} org.jacoco:jacoco-maven-plugin:prepare-agent test verify
-fi
+mvn ${MVN_ARGS} org.jacoco:jacoco-maven-plugin:prepare-agent test verify


### PR DESCRIPTION
as apparently the [build](https://travis-ci.com/github/retest/recheck-web-archetype/builds/174935303#L748) is failing for some reason now. When checking the log, there was no sonar cloud token present in the past and creating a project in sonar cloud did not work either.

I think that we can remove sonar cloud safely, because there is nothing really to be checked.